### PR TITLE
Respond when no ASID, add X-FILES/DANA ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,9 @@ HEADERS_V          = ../nnsim-hdl/src/ram_infer_preloaded_cache.v \
 # RISCV Tests Targets
 RV_TESTS             = hello.c \
 	fann-xfiles.c \
-	fann-soft.c
+	fann-soft.c \
+	write-on-invalid-asid.c \
+	read-xfiles-dana-info.c
 RV_TESTS_EXECUTABLES = $(RV_TESTS:%.c=$(DIR_BUILD)/%.rv)
 RV_TESTS_DISASM      = $(RV_TESTS:%.c=$(DIR_BUILD)/%.rvS)
 

--- a/src/main/c/xfiles.h
+++ b/src/main/c/xfiles.h
@@ -23,7 +23,27 @@ typedef enum {
   xfiles_reg_weight_decay_lambda
 } xfiles_reg;
 
+typedef enum {
+  READ_DATA = 0,
+  WRITE_DATA = 1,
+  NEW_REQUEST = 3,
+  WRITE_DATA_LAST = 5,
+  WRITE_REGISTER = 7,
+  XFILES_DANA_ID = 16
+} request_t;
+
+typedef enum {
+  UPDATE_ASID = 0,
+  UPDATE_ANTP = 1
+} request_super_t;
+
+
 //-------------------------------------- Userland
+
+// Request information about the specific X-FILES/DANA configuration
+// and return it in an XLen sized packed representation. Optionally,
+// this will print the output directly to stdout.
+x_len xfiles_dana_id(int flag_print);
 
 // Initiate a new Transaction for a specific NNID. The X-Files Arbiter
 // will then assign and return a TID necessary for other userland

--- a/src/main/scala/AsidUnit.scala
+++ b/src/main/scala/AsidUnit.scala
@@ -16,29 +16,27 @@ class AsidUnitANTWInterface(implicit p: Parameters) extends XFilesBundle()(p) {
   val req = Decoupled(new ANTWRequest)
 }
 
-class asid(implicit p: Parameters) extends XFilesBundle()(p) {
-  val valid = Bool()
+class AsidTid(implicit p: Parameters) extends XFilesBundle()(p) {
   val asid = UInt(width = asidWidth)
   val tid = UInt(width = tidWidth)
 }
 
-class AsidUnit(implicit p: Parameters) extends DanaModule()(p) with XFilesParameters {
+class AsidUnit(implicit p: Parameters) extends XFilesModule()(p) {
   val io = new XFilesBundle {
     val core = new XFilesBundle {
       val cmd = Valid(new RoCCCommand()(p)).flip
       val s = Bool(INPUT)
     }
     val antw = new AsidUnitANTWInterface
-    val asid = UInt(OUTPUT, width = asidWidth)
-    val tid = UInt(OUTPUT, width = tidWidth)
+    val data = Valid(new AsidTid)
   }
 
-  val asidReg = Reg(new asid)
+  val asidReg = Reg(Valid(new AsidTid))
 
-  val updateAsid = io.core.s && io.core.cmd.bits.inst.funct === UInt(0)
-  val updateANTP = io.core.s && io.core.cmd.bits.inst.funct === UInt(1)
-  val newRequest = !io.core.s && io.core.cmd.bits.inst.funct(0) &&
-    io.core.cmd.bits.inst.funct(1) && !io.core.cmd.bits.inst.funct(2)
+  val funct = io.core.cmd.bits.inst.funct
+  val updateAntp = io.core.s && funct === t_UPDATE_ANTP
+  val updateAsid = io.core.s && funct === t_UPDATE_ASID
+  val newRequest = !io.core.s && funct === t_NEW_REQUEST
 
   // Defaults
   io.antw.req.valid := Bool(false)
@@ -49,16 +47,17 @@ class AsidUnit(implicit p: Parameters) extends DanaModule()(p) with XFilesParame
   // ASID-update request, set the ASID and reset the TID counter.
   when (io.core.cmd.fire() && updateAsid) {
     asidReg.valid := Bool(true)
-    asidReg.asid := io.core.cmd.bits.rs1(asidWidth - 1, 0)
-    asidReg.tid := UInt(0)
+    asidReg.bits.asid := io.core.cmd.bits.rs1(asidWidth - 1, 0)
+    asidReg.bits.tid := UInt(0)
     printfInfo("Saw supervisor request to update ASID to 0x%x\n",
       io.core.cmd.bits.rs1(asidWidth - 1, 0));
     // [TODO] This needs to respond to the core with the ASID and TID
     // so that the OS can save the ASID/TID for reloading later.
   }
+
   // Generate a request that updates the ASID--NNID Table Pointer if
   // we see this request on the RoCCInterface
-  when (io.core.cmd.fire() && updateANTP) {
+  when (io.core.cmd.fire() && updateAntp) {
     io.antw.req.valid := Bool(true);
     io.antw.req.bits.antp := io.core.cmd.bits.rs1;
     io.antw.req.bits.size := io.core.cmd.bits.rs2;
@@ -66,21 +65,13 @@ class AsidUnit(implicit p: Parameters) extends DanaModule()(p) with XFilesParame
       io.core.cmd.bits.rs1,
       io.core.cmd.bits.rs2);
   }
-  when (io.core.cmd.fire() && newRequest) {
-    asidReg.tid := asidReg.tid + UInt(1)
-    printfInfo("AsidUnit: Saw new request funct/rs1/rs2 0x%x/0x%x/0x%x\n",
-      io.core.cmd.bits.inst.funct, io.core.cmd.bits.rs1, io.core.cmd.bits.rs2)
+
+  when (io.core.cmd.fire() & newRequest & asidReg.valid) {
+    asidReg.bits.tid := asidReg.bits.tid + UInt(1)
   }
-  io.asid := asidReg.asid
-  io.tid := asidReg.tid
+
+  io.data := asidReg
 
   // Reset
-  when (reset) {
-    asidReg.valid := Bool(false)
-  }
-
-  // Assertions
-  // There shouldn't be a new request on an invalid ASID
-  assert(!(io.core.cmd.fire() && newRequest && !asidReg.valid),
-    "New request on invalid ASID (a clean build may be needed)");
+  when (reset) { asidReg.valid := Bool(false) }
 }

--- a/src/main/scala/XFilesDana.scala
+++ b/src/main/scala/XFilesDana.scala
@@ -69,10 +69,6 @@ class XFilesDana(implicit p: Parameters) extends RoCC()(p) {
     io.utl(i).acquire.valid := Bool(false)
     io.utl(i).grant.ready := Bool(true)}
 
-  io.iptw.req.valid := Bool(false)
-  io.dptw.req.valid := Bool(false)
-  io.pptw.req.valid := Bool(false)
-
   xFilesArbiter.io.dana <> dana.io
 
   // Assertions

--- a/src/test/rv/read-xfiles-dana-id.c
+++ b/src/test/rv/read-xfiles-dana-id.c
@@ -1,0 +1,6 @@
+#include "xfiles.h"
+
+int main (int argv, char * argc[]) {
+  xfiles_dana_id(1);
+  return 0;
+}

--- a/src/test/rv/write-on-invalid-asid.c
+++ b/src/test/rv/write-on-invalid-asid.c
@@ -1,0 +1,11 @@
+#include "xfiles.h"
+
+int main (int argv, char * argc[]) {
+  printf("%s: START\n", argc[0]);
+
+  tid_type tid = new_write_request(0, 0, 0);
+  printf("TID on write with invalid ASID: %d\n", tid);
+
+  printf("%s: END\n", argc[0]);
+  return 0;
+}


### PR DESCRIPTION
When the X-FILES arbiter receives a new write request on an invalid
ASID, the arbiter squashes the request from getting to the Transaction
Table and responds with a value of -1. A basic C program is included
that demonstrates this functionality.

This adds a new X-FILES/DANA ID function that will respond with some
information about the X-FILES/DANA configuration. The request is
squashed in the same fashion as with an invalid new write request.

The request types now use enumerated types defined in both the X-FILES
software libraries and in the abstract XFilesModule class.
