### PR TITLE
Get smoke tests running again

### DIFF
--- a/src/main/scala/xfiles/Arbiter.scala
+++ b/src/main/scala/xfiles/Arbiter.scala
@@ -41,12 +41,12 @@ class XFilesArbiter()(implicit p: Parameters)
   val asidValid = csrFile.io.status.asidValid
 
   // Types of requests
-  val badRequest = cmd.fire() & (
-    (!asidValid & !sup & (funct =/= t_USR_XFILES_DEBUG.U | funct =/= t_SUP_READ_CSR.U)) |
-      (asidValid & !sup & (funct < t_USR_READ_DATA.U & funct =/= t_SUP_READ_CSR.U)))
   val readCsr = cmd.fire() & funct === t_SUP_READ_CSR.U
   val writeCsr = cmd.fire() & funct === t_SUP_WRITE_CSR.U
   val isDebug = cmd.fire() & funct === t_USR_XFILES_DEBUG.U
+  val badRequest = cmd.fire() & (
+    (!asidValid & !sup & !(funct === t_USR_XFILES_DEBUG.U | funct === t_SUP_READ_CSR.U)) |
+      (asidValid & !sup & (funct < t_USR_READ_DATA.U & funct =/= t_SUP_READ_CSR.U)))
 
   // Anything that is a short circuit response or involves a
   // supervisor request gets squashed.

--- a/tests/Makefrag
+++ b/tests/Makefrag
@@ -24,11 +24,11 @@ HEADERS_V := $(HEADERS) $(shell find $(ENV_P))
 top_build_dir = $(abs_top_srcdir)/../build/nets
 
 # Compute the ID String
-ID_TTABLE ?= 1
+TTABLE_ENTRIES ?= 2
 EPB ?= 4
-PES ?= 1
-ID_CACHE ?= 2
-ID_STRING ?= 0x$(shell echo "obase=16; $(ID_CACHE) + ($(PES) * (2 ^ 4)) + ($(EPB) * (2 ^ 10)) + ($(ID_TTABLE) * (2 ^ 48))" | bc)
+NUM_PES ?= 4
+CACHE_ENTRIES ?= 1
+ID_STRING ?= 0x$(shell echo "obase=16; $(CACHE_ENTRIES) + ($(NUM_PES) * (2 ^ 4)) + ($(EPB) * (2 ^ 10)) + ($(TTABLE_ENTRIES) * (2 ^ 48))" | bc)
 
 default: all
 src_dir = .

--- a/tests/libs/src/xfiles-debug.S
+++ b/tests/libs/src/xfiles-debug.S
@@ -21,11 +21,11 @@
   la x ## rs2, addr;                                                    \
   ROCC_INSTRUCTION_RAW_R_R_R(CUSTOM_X, rd, rs1, rs2, t_USR_XFILES_DEBUG);
 
-#define DEBUG_ECHO_VIA_REG(data) DEBUG_TEST(a_REG, data, tdat, 3, 1, 2)
-#define DEBUG_READ_MEM(addr) DEBUG_TEST(a_MEM_READ, 0, addr, 3, 1, 2);
-#define DEBUG_WRITE_MEM(data, addr) DEBUG_TEST(a_MEM_WRITE, data, addr, 3, 1, 2);
-#define DEBUG_VIRT_TO_PHYS(vaddr, paddr) DEBUG_TEST(a_VIRT_TO_PHYS, 0, vaddr, paddr, 1, 2);
-#define DEBUG_READ_UTL(addr) DEBUG_TEST(a_UTL_READ, 0, addr, 3, 1, 2);
-#define DEBUG_WRITE_UTL(data, addr) DEBUG_TEST(a_UTL_WRITE, data, addr, 3, 1, 2);
+#define DEBUG_ECHO_VIA_REG(data) DEBUG_TEST(a_REG, data, tdat, 10, 10, 11)
+#define DEBUG_READ_MEM(addr) DEBUG_TEST(a_MEM_READ, 0, addr, 10, 10, 11);
+#define DEBUG_WRITE_MEM(data, addr) DEBUG_TEST(a_MEM_WRITE, data, addr, 10, 10, 11);
+#define DEBUG_VIRT_TO_PHYS(vaddr, paddr) DEBUG_TEST(a_VIRT_TO_PHYS, 0, vaddr, paddr, 10, 11);
+#define DEBUG_READ_UTL(addr) DEBUG_TEST(a_UTL_READ, 0, addr, 10, 10, 11);
+#define DEBUG_WRITE_UTL(data, addr) DEBUG_TEST(a_UTL_WRITE, data, addr, 10, 10, 11);
 
 #endif  // XFILES_DANA_LIBS_SRC_XFILES_DEBUG_S_

--- a/tests/smoke/debug.S
+++ b/tests/smoke/debug.S
@@ -19,11 +19,11 @@
 RVTEST_WITH_ROCC
 
 RVTEST_CODE_BEGIN
-  TEST_CASE( 1, x3, 0xaaaa, DEBUG_ECHO_VIA_REG(0xaaaa) );
-  TEST_CASE( 2, x3, 0x0,    DEBUG_WRITE_MEM(0xbbbb, tdat2) );
-  TEST_CASE( 3, x3, 0xbbbb, DEBUG_READ_MEM(tdat3) );
-  TEST_CASE( 4, x3, 0x0,    DEBUG_WRITE_UTL(0xcccc, tdat4) );
-  TEST_CASE( 5, x3, 0xcccc, DEBUG_READ_UTL(tdat5) );
+  TEST_CASE( 1, x10, 0xaaaa, DEBUG_ECHO_VIA_REG(0xaaaa) );
+  TEST_CASE( 2, x10, 0x0,    DEBUG_WRITE_MEM(0xbbbb, tdat2) );
+  TEST_CASE( 3, x10, 0xbbbb, DEBUG_READ_MEM(tdat3) );
+  TEST_CASE( 4, x10, 0,    DEBUG_WRITE_UTL(0xcccc, tdat4) );
+  TEST_CASE( 5, x10, 0xcccc, DEBUG_READ_UTL(tdat5) );
 
   TEST_PASSFAIL
 


### PR DESCRIPTION
See #49.

This fixes a bug in how a bad request was determined by the arbiter.

Additionally, the ID string is cleaned up to match the configuration specified in the README.